### PR TITLE
Update JWT handling

### DIFF
--- a/mobile/app/(auth)/login.js
+++ b/mobile/app/(auth)/login.js
@@ -36,9 +36,6 @@ export default function Login() {
         text: 'OK',
         style: 'cancel'
       }]);
-      // Clear text inputs
-      setUserID('');
-      setPassword('');
     } else {
       router.navigate('/home');
     }

--- a/mobile/app/organizations/[org]/(tabs)/matches.js
+++ b/mobile/app/organizations/[org]/(tabs)/matches.js
@@ -49,7 +49,6 @@ const profiles = [
 
 export default function SwipePage() {
   const { org } = useLocalSearchParams();
-  console.log(org);
 
   const [profileIndex, setProfileIndex] = useState(0); //Current profile index
   const swipeAnim = useRef(new Animated.Value(0)).current; // Animation of horizontal swipe

--- a/mobile/app/organizations/_layout.js
+++ b/mobile/app/organizations/_layout.js
@@ -1,16 +1,26 @@
 import { Text } from 'react-native';
-import { Redirect, Stack } from 'expo-router';
+import { Redirect, useLocalSearchParams, Stack } from 'expo-router';
 
+import useAuth from '@context/useAuth';
 import { useSession } from '@context/ctx';
 
 export default function OrganizationsLayout() {
   const { session, isLoading } = useSession();
-
+  
   if (isLoading) {
     return <Text>Loading...</Text>;
   }
+
+  // User is not logged in
   if (!session) {
     return <Redirect href="/" />;
+  }
+
+  // User is logged in, but not in the organization
+  const { _, profiles } = useAuth();
+  const { org } = useLocalSearchParams();
+  if (!profiles.some(profile => profile.organizationId === org)) {
+    return <Redirect href="/home" />;
   }
 
   return (

--- a/mobile/context/ctx.js
+++ b/mobile/context/ctx.js
@@ -1,7 +1,8 @@
 // See https://docs.expo.dev/router/reference/authentication/
 
-import { useContext, createContext } from 'react';
+import { useEffect, useContext, createContext } from 'react';
 import { useStorageState } from './useStorageState';
+import { jwtDecode, InvalidTokenError } from 'jwt-decode';
 
 import Constants from "expo-constants";
 
@@ -26,6 +27,25 @@ export function useSession() {
 
 export function SessionProvider({ children }) {
   const [[isLoading, session], setSession] = useStorageState('session');
+  
+  useEffect(() => {
+    if (session !== null) {
+      try {
+        // Check if JWT is expired
+        const decoded = jwtDecode(session);
+        if (Date.now() >= decoded.exp * 1000) {
+          setSession(null);
+        }
+      } catch (e) {
+        // JWT is in invalid format
+        if (e instanceof InvalidTokenError) {
+          setSession(null);
+        } else {
+          throw e;
+        }
+      }
+    }
+  }, [session]);
 
   return (
     <AuthContext.Provider

--- a/server/controllers/imageController.js
+++ b/server/controllers/imageController.js
@@ -57,11 +57,11 @@ const getImage = (req, res) => {
   if (id === MOCK_IMAGE_ID) {
     switch (bucket) {
       case "profile": {
-        image = "https://xsgames.co/randomusers/avatar.php?g=male";
+        image = `https://xsgames.co/randomusers/avatar.php?g=male?${new Date()}`;
         break;
       }
       case "organization": {
-        image = "https://picsum.photos/200";
+        image = `https://picsum.photos/200?${new Date()}`;
         break;
       }
       default: {

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -124,6 +124,7 @@ const loginUser = async (req, res) => {
         const profiles = await Profile.find({ userId: user._id }).populate('organizationId').exec();
         const profilesArray = profiles.map(profile => ({
             id: profile._id,
+            organizationId: profile.organizationId._id,
             isOwner: profile.organizationId.owner.equals(user._id)
         }));
 

--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -2,7 +2,7 @@ const jwt = require("jsonwebtoken");
 
 const verifyToken = (req, res, next) => {
     // Require JWT token
-    let token = req.cookies["Authorization"];
+    let token = req.headers["authorization"];
     if (token === undefined) {
         return res.status(401).send("Cannot access resource, no JWT provided!");
     }


### PR DESCRIPTION
- Modified `useContext` to check if the JWT has expired before returning it. 
- Protected Organization pages in the frontend. Users that are not part of an organization should not be allowed to view them.
- Changed middleware to check JWT in headers instead of cookies.

