### PR TITLE
Make matching page interactive with real data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 PORT=5000
 MONGO_URI=__________
 JWT_SECRET_KEY=__________
+AWS_ACCESS_KEY_ID=__________
+AWS_SECRET_ACCESS_KEY=__________
+AWS_REGION=__________
+AWS_S3_BUCKET_NAME=__________
 
 // Create a .env file in the root directory and add the above code w/ your own specific uri
 // ***DO NOT COMMIT .env FILE TO GITHUB***

--- a/mobile/app/(tabs)/explore.js
+++ b/mobile/app/(tabs)/explore.js
@@ -74,11 +74,13 @@ export default function Explore() {
             style={styles.orgContainer}
             contentContainerStyle={{ padding: 20, gap: 20 }}
             data={orgs}
-            renderItem={({ item }) => <OrganizationCard
+            renderItem={({ item }) =>
+              <OrganizationCard
                 org={item}
-                onPress={() => handlePress(item.id)}
-              />}
-            keyExtractor={item => item.id}
+                onPress={() => handlePress(item._id)}
+              />
+            }
+            keyExtractor={item => item._id}
           />
           <View style={styles.button}>
             <StyledButton

--- a/mobile/app/(tabs)/home.js
+++ b/mobile/app/(tabs)/home.js
@@ -69,7 +69,7 @@ export default function Home() {
             renderItem={({ item }) => (
               <OrganizationCard
                 org={item} 
-                onPress={() => router.push(`/organizations/${item.id}/matches`)}
+                onPress={() => router.push(`/organizations/${item._id}/matches`)}
               />
             )}
           />

--- a/mobile/components/OrganizationCard.js
+++ b/mobile/components/OrganizationCard.js
@@ -4,6 +4,8 @@ import { Pressable, View, Image, Text, StyleSheet } from "react-native";
   Organization Card Component - Displays organization information for the Explore page
 */
 export default function OrganizationCard({ org, onPress }) {
+  const size = org.members.length;
+
   return (
     <Pressable style={styles.container} onPress={onPress}>
       {org.joined && (
@@ -20,7 +22,7 @@ export default function OrganizationCard({ org, onPress }) {
           {org.description}
         </Text>
       </View>
-      <Text style={styles.size}>{org.size} {org.size == 1 ? "Member" : "Members"}</Text>
+      <Text style={styles.size}>{size} {size == 1 ? "Member" : "Members"}</Text>
     </Pressable>
   );
 };

--- a/mobile/components/ProfileCard.js
+++ b/mobile/components/ProfileCard.js
@@ -1,0 +1,115 @@
+import { useRef, useState, useCallback } from 'react';
+import { Pressable, ImageBackground, View, Text, StyleSheet } from "react-native";
+
+/*
+  Profile Card Component - Displays profile for the Matches page
+*/
+export default function ProfileCard({ profile }) {
+  const interests = profile.interests.slice(1);
+  
+  const width = useRef();
+  
+  const handleLayout = (event) => {
+    if (event === undefined) return;
+    width.current = event.nativeEvent.layout.width;
+  }
+
+  const [imageIndex, setImageIndex] = useState(0);
+
+  const handlePress = useCallback((event) => {
+    if (event.nativeEvent.locationX < width.current / 2) { // Left side tap
+      if (imageIndex === 0) return;
+      setImageIndex(imageIndex - 1);
+    } else { // Right side tap
+      if (imageIndex === profile.images.length - 1) return;
+      setImageIndex(imageIndex + 1);
+    }
+  }, [imageIndex]);
+
+  return (
+    <Pressable
+      style={styles.container}
+      onPress={handlePress}
+      onLayout={handleLayout}
+    >
+      <ImageBackground
+        style={styles.card}
+        source={{ uri: profile.images[imageIndex] }}
+        resizeMode="cover"
+      >
+        <View style={styles.progress}>
+          {profile.images.length > 1 && profile.images.map((_, i) => {
+            return (
+              <View
+                key={i}
+                style={[styles.progressBar, i === imageIndex && styles.active]}>
+              </View>
+            )
+          })}
+        </View>
+        <View style={styles.info}>
+          <View style={styles.headerLine}>
+            <Text style={styles.name}>{profile.profileName}</Text>
+            <Text style={styles.major}>{profile.major}</Text>
+          </View>
+          <Text style={styles.description}>{profile.description}</Text>
+          {interests.length > 0 &&
+            <Text style={styles.interests}>Interests: {interests.join(', ')}</Text>
+          }
+        </View>
+      </ImageBackground>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  card: {
+    flex: 1,
+    display: 'flex',
+    justifyContent: 'space-between',
+    backgroundColor: '#ffffff' // Fallback background if image does not exist,
+  },
+  progress: {
+    display: 'flex',
+    flexDirection: 'row',
+    gap: 5,
+    paddingHorizontal: 5,
+    marginTop: 5
+  },
+  progressBar: {
+    flex: 1,
+    height: 5,
+    backgroundColor: 'rgba(255, 255, 255, 0.6)'
+  },
+  active: {
+    backgroundColor: 'white'
+  },
+  info: {
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+    padding: 10,
+  },
+  headerLine: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10
+  },
+  name: {
+    fontSize: 30,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+  major: {
+    fontSize: 15,
+    color: 'white'
+  },
+  description: {
+    color: 'white'
+  },
+  interests: {
+    color: 'white'
+  }
+})

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -23,6 +23,7 @@
         "mobile": "file:",
         "react": "^18.3.1",
         "react-native": "^0.76.6",
+        "react-native-deck-swiper": "^2.0.17",
         "react-native-picker": "^4.3.7",
         "react-native-safe-area-context": "^4.12.0",
         "react-native-screens": "^4.4.0"
@@ -5098,6 +5099,12 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js."
+    },
     "node_modules/core-js-compat": {
       "version": "3.40.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.40.0.tgz",
@@ -5383,6 +5390,14 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/end-of-stream": {
@@ -6411,6 +6426,17 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "funding": [
@@ -6734,6 +6760,24 @@
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
+      "dependencies": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      }
+    },
+    "node_modules/isomorphic-fetch/node_modules/node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dependencies": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -9086,6 +9130,66 @@
         }
       }
     },
+    "node_modules/react-native-deck-swiper": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/react-native-deck-swiper/-/react-native-deck-swiper-2.0.17.tgz",
+      "integrity": "sha512-vOGmhBLnrVQL6WtwmgdUqKOyKwoDRmozYjEygRHvFEjHwyFohpd9scDPRNc0t9HlKcXRVNunVsN45B9emqNybw==",
+      "dependencies": {
+        "prop-types": "15.5.10"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0-beta.5 || ^17.0.0 || ^18.0.0",
+        "react-native": ">=0.49.1"
+      }
+    },
+    "node_modules/react-native-deck-swiper/node_modules/fbjs": {
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
+      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
+      "dependencies": {
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.30"
+      }
+    },
+    "node_modules/react-native-deck-swiper/node_modules/prop-types": {
+      "version": "15.5.10",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+      "integrity": "sha512-vCFzoUFaZkVNeFkhK1KbSq4cn97GDrpfBt9K2qLkGnPAEFhEv3M61Lk5t+B7c0QfMLWo0fPkowk/4SuXerh26Q==",
+      "dependencies": {
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1"
+      }
+    },
+    "node_modules/react-native-deck-swiper/node_modules/ua-parser-js": {
+      "version": "0.7.40",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.40.tgz",
+      "integrity": "sha512-us1E3K+3jJppDBa3Tl0L3MOJiGhe1C6P0+nIvQAFYbxlMAx0h81eOwLmU57xgqToduDDPx3y5QsdjPfDu+FgOQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/react-native-helmet-async": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-native-helmet-async/-/react-native-helmet-async-2.0.4.tgz",
@@ -9459,6 +9563,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sax": {
       "version": "1.4.1",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8075,8 +8075,28 @@
       }
     },
     "node_modules/mobile": {
-      "resolved": "",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "file:",
+      "dependencies": {
+        "@expo-google-fonts/inter": "^0.2.3",
+        "@react-native-picker/picker": "^2.9.0",
+        "axios": "^1.7.3",
+        "expo": "^52.0.25",
+        "expo-constants": "~17.0.7",
+        "expo-font": "^13.0.3",
+        "expo-image-picker": "^16.0.4",
+        "expo-linking": "^7.0.4",
+        "expo-router": "^4.0.5",
+        "expo-secure-store": "^14.0.1",
+        "expo-status-bar": "^2.0.1",
+        "jwt-decode": "^4.0.0",
+        "mobile": "file:",
+        "react": "^18.3.1",
+        "react-native": "^0.76.6",
+        "react-native-picker": "^4.3.7",
+        "react-native-safe-area-context": "^4.12.0",
+        "react-native-screens": "^4.4.0"
+      }
     },
     "node_modules/mrmime": {
       "version": "1.0.1",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -24,6 +24,7 @@
     "mobile": "file:",
     "react": "^18.3.1",
     "react-native": "^0.76.6",
+    "react-native-deck-swiper": "^2.0.17",
     "react-native-picker": "^4.3.7",
     "react-native-safe-area-context": "^4.12.0",
     "react-native-screens": "^4.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6586,8 +6586,33 @@
       }
     },
     "node_modules/big_and_little": {
-      "resolved": "",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "file:",
+      "license": "ISC",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.758.0",
+        "@aws-sdk/s3-request-presigner": "^3.758.0",
+        "@expo/vector-icons": "^14.0.4",
+        "@react-native-picker/picker": "^2.11.0",
+        "@react-navigation/native": "^7.0.2",
+        "@react-navigation/stack": "^7.0.2",
+        "bcrypt": "^5.1.1",
+        "big_and_little": "file:",
+        "cookie-parser": "^1.4.7",
+        "cors": "^2.8.5",
+        "dotenv": "^16.4.5",
+        "expo": "^51.0.38",
+        "expo-image-picker": "^16.0.4",
+        "expo-secure-store": "^14.0.1",
+        "express": "^4.19.2",
+        "jsonwebtoken": "^9.0.2",
+        "mongoose": "^8.7.2",
+        "multer": "^1.4.5-lts.1",
+        "react-native-safe-area-context": "^4.14.0",
+        "react-native-screens": "^4.1.0",
+        "react-native-web": "~0.19.10",
+        "uuid": "^11.1.0"
+      }
     },
     "node_modules/big-integer": {
       "version": "1.6.52",

--- a/server/controllers/orgController.js
+++ b/server/controllers/orgController.js
@@ -5,70 +5,63 @@ const Profile = require('../models/Profile');
 
 // Function to generate a unique joinCode
 const generateUniqueJoinCode = async () => {
-    let joinCode;
-    let isUnique = false;
+  let joinCode;
+  let isUnique = false;
 
-    while (!isUnique) {
-        joinCode = crypto.randomInt(100000, 999999); 
+  while (!isUnique) {
+    joinCode = crypto.randomInt(100000, 999999); 
 
-        const existingOrg = await Organization.findOne({ joinCode }).exec();
-        if (!existingOrg) {
-            isUnique = true; 
-        }
+    const existingOrg = await Organization.findOne({ joinCode }).exec();
+    if (!existingOrg) {
+      isUnique = true; 
     }
-    return joinCode;
+  }
+  return joinCode;
 };
 
 // @desc Get public organizations
 // @route GET /organizations
 // @access Public
 const getOrganizations = async (req, res) => {
-    try {
-        const orgs = await Organization.find({ isPublic: true, isMatching: false }).exec();
-        const orgsArray = orgs.map(org => ({
-            id: org.id,
-            name: org.name,
-            description: org.description,
-            logo: org.logo,
-            size: org.members.length,
-        }));
-        return res.status(200).send(orgsArray);
-    } catch (err) { // Server error (Probably a Mongoose connection issue)
-        return res.status(500).send();
-    }
+  try {
+    const orgs = await Organization.find({ isPublic: true, isMatching: false }).exec();
+    return res.json(orgs);
+  } catch (err) { // Server error (Probably a Mongoose connection issue)
+    return res.status(500).send();
+  }
 }
 
 // @desc Create a new organization
 // @route POST /create-org
 const createOrganization = async (req, res) => {
-    const { name, description, owner } = req.body;
+  const { name, description, owner } = req.body;
 
-    if (!name) {
-        return res.status(400).json({ message: "Organization name is required" });
-    }
+  if (!name) {
+    return res.status(400).json({ message: "Organization name is required" });
+  }
 
-    try {
-        const joinCode = await generateUniqueJoinCode();
-        const newOrg = new Organization({
-            name,
-            description: description || "",
-            logo: "DEFAULT_LOGO_ID",
-            isPublic: true,
-            isMatching: false,
-            joinCode: joinCode,
-            owner: owner, // This should be a valid Profile ObjectId, rn it is a userID
-            members: [owner], // Add owner as the first member
-            rounds: 3,
-            roundWeighting: [1, 3, 5],
-            swipesPerRound: [20, 10, 5],
-            currentRound: 0
-        });
+  try {
+    const joinCode = await generateUniqueJoinCode();
+    const newOrg = new Organization({
+      name,
+      description: description || "",
+      logo: "DEFAULT_LOGO_ID",
+      isPublic: true,
+      isMatching: false,
+      joinCode: joinCode,
+      owner: owner, // This should be a valid Profile ObjectId, rn it is a userID
+      members: [owner], // Add owner as the first member
+      rounds: 3,
+      roundWeighting: [1, 3, 5],
+      swipesPerRound: [20, 10, 5],
+      currentRound: 0
+    });
 
-        await newOrg.save();
-        return res.status(201).json({ message: "Organization created successfully", org: newOrg });
-    } catch (err) {
-        return res.status(500).json({ message: "Server error", error: err.message });
-    }
+    await newOrg.save();
+    return res.status(201).json({ message: "Organization created successfully", org: newOrg });
+  } catch (err) {
+    return res.status(500).json({ message: "Server error", error: err.message });
+  }
 };
 
 
@@ -76,57 +69,181 @@ const createOrganization = async (req, res) => {
 // @route GET /organizations/:orgId
 // @access Private
 const getOrganizationById = async (req, res) => {
-    try {
-        const { orgId } = req.params;
-        if (!orgId) {
-            return res.status(400).json({ message: 'id field required.' });
-        }
-
-        const org = await Organization.findById(orgId);
-        if (org) {
-            return res.json({
-                id: org.id,
-                name: org.name,
-                description: org.description,
-                logo: org.logo,
-                size: org.members.length
-            });
-        }
-
-        return res.status(404).send();
+  try {
+    const { orgId } = req.params;
+    if (!orgId) {
+      return res.status(400).json({ message: 'id field required.' });
     }
-    catch (err) {
-        return res.status(500).send();
+
+    const org = await Organization.findById(orgId);
+    if (org) {
+      return res.json(org);
     }
+
+    return res.status(404).send();
+  }
+  catch (err) {
+    return res.status(500).send();
+  }
 };
 
 // @desc Get a specific organizations members
 // @route GET /organizations/:orgId/members
 // @access Private
 const getOrganizationMembers = async (req, res) => {
-    try {
-        const { orgId } = req.params;
-        if (!orgId) {
-            return res.status(400).json({ message: 'id field required.' });
-        }
-
-        const org = await Organization.findById(orgId);
-        if (!org) {
-            return res.status(404).send();
-        }
-
-        const profiles = await Profile.find({ _id: { $in: org?.members } }).exec();
-
-        if (!profiles) {
-            return res.status(404).send();
-        }
-
-        return res.json(profiles);
+  try {
+    const { orgId } = req.params;
+    if (!orgId) {
+      return res.status(400).json({ message: 'id field required.' });
     }
-    catch (err) {
-        return res.status(500).send();
+
+    const org = await Organization.findById(orgId);
+    if (!org) {
+      return res.status(404).send();
     }
+
+    const profiles = await Profile.find({ _id: { $in: org?.members } }).exec();
+
+    if (!profiles) {
+      return res.status(404).send();
+    }
+
+    return res.json(profiles);
+  }
+  catch (err) {
+    return res.status(500).send();
+  }
 };
 
+// @desc Get matches for a profile
+// @route GET /organizations/:orgId/matches/profiles
+// @access Private
+const getMatchProfiles = async (req, res) => {
+  const { orgId } = req.params;
+  const userProfiles = req.profiles;
+  if (!orgId) return res.status(400).send('Organization ID is required!');
+  
+  const org = await Organization.findById(orgId);
+  if (!org) return res.status(400).send(`No organization with ID ${orgId} exists!`);
+  if (!org.isMatching) return res.status(400).send('Organization is not currently matching!');
+  
+  const userProfileId = userProfiles.find(p => p.organizationId === orgId)?.id;
+  if (!userProfileId) return res.status(400).send('User is not a member of the organization!');
+  
+  const userProfile = await Profile.findById(userProfileId);
+  
+  // Get all members in the organization
+  let profiles = await Profile.find({ _id: { $in: org.members } }).exec();
+  
+  // Get Bigs for Littles, and Littles for Bigs
+  profiles = profiles.filter(p => p.role !== userProfile.role);
+  
+  // Filter out members that user has already swiped on
+  const round = userProfile.rounds[org.currentRound];
+  let swipes = [];
+  if (round) {
+    swipes = round.swipesLeft.concat(round.swipesRight);
+    profiles = profiles.filter(p => !swipes.map(id => id.toString()).includes(p._id.toString()));
+  }
 
-module.exports = { getOrganizations, getOrganizationById, getOrganizationMembers, createOrganization };
+  // Determine number of swipes user has left
+  const remainingSwipes = org.swipesPerRound[org.currentRound] - swipes.length;
+  
+  return res.json({
+    "profiles": profiles,
+    "swipes": remainingSwipes
+  });
+}
+
+// @desc Swipes left on a profile
+// @route POST /organizations/:orgId/matches/swipeLeft/:profileId
+// @access Private
+const swipeLeft = async (req, res) => {
+  const { orgId, profileId } = req.params;
+  const userProfiles = req.profiles;
+  if (!orgId || !profileId) return res.status(400).send('Please provide an organization and profile ID!');
+
+  const org = await Organization.findById(orgId);
+  if (!org) return res.status(400).send(`Organization with ID ${orgId} does not exist!`);
+  if (!org.isMatching) return res.status(400).send('Organization is not currently matching!');
+
+  const userProfileId = userProfiles.find(p => p.organizationId === orgId).id;
+  const userProfile = await Profile.findById(userProfileId);
+  
+  let round = userProfile.rounds[org.currentRound];
+  if (!round) {
+    round = {
+      swipesLeft: [],
+      swipesRight: []
+    };
+  }
+  
+  // Check validity of swipe
+  if (round.swipesLeft.length + round.swipesRight.length === org.swipesPerRound[org.currentRound]) {
+    return res.status(400).send('User has no more swipes!');
+  } else if (round.swipesLeft.includes(profileId) || round.swipesRight.includes(profileId)) {
+    return res.status(400).send('User has already swiped on this profile!');
+  }
+  
+  const profile = await Profile.findById(profileId);
+  if (!profile) return res.status(400).send(`Profile with ID ${profileId} does not exist!`);
+  round.swipesLeft.push(profile._id);
+
+  // Save
+  userProfile.rounds[org.currentRound] = round;
+  await userProfile.save();
+  
+  return res.status(200).send();
+}
+
+// @desc Swipes right on a profile
+// @route POST /organizations/:orgId/matches/swipeRight/:profileId
+// @access Private
+const swipeRight = async (req, res) => {
+  const { orgId, profileId } = req.params;
+  const userProfiles = req.profiles;
+  if (!orgId || !profileId) return res.status(400).send('Please provide an organization and profile ID!');
+
+  const org = await Organization.findById(orgId);
+  if (!org) return res.status(400).send(`Organization with ID ${orgId} does not exist!`);
+  if (!org.isMatching) return res.status(400).send('Organization is not currently matching!');
+
+  const userProfileId = userProfiles.find(p => p.organizationId === orgId).id;
+  const userProfile = await Profile.findById(userProfileId);
+  
+  let round = userProfile.rounds[org.currentRound];
+  if (!round) {
+    round = {
+      swipesLeft: [],
+      swipesRight: []
+    };
+  }
+  
+  // Check validity of swipe
+  if (round.swipesLeft.length + round.swipesRight.length === org.swipesPerRound[org.currentRound]) {
+    return res.status(400).send('User has no more swipes!');
+  } else if (round.swipesLeft.includes(profileId) || round.swipesRight.includes(profileId)) {
+    return res.status(400).send('User has already swiped on this profile!');
+  }
+  
+  const profile = await Profile.findById(profileId);
+  if (!profile) return res.status(400).send(`Profile with ID ${profileId} does not exist!`);
+  round.swipesRight.push(profile._id);
+
+  // Save
+  userProfile.rounds[org.currentRound] = round;
+  await userProfile.save();
+
+  return res.status(200).send();
+}
+
+
+module.exports = {
+  getOrganizations,
+  getOrganizationById,
+  getOrganizationMembers,
+  createOrganization,
+  getMatchProfiles,
+  swipeLeft,
+  swipeRight
+};

--- a/server/models/Profile.js
+++ b/server/models/Profile.js
@@ -49,11 +49,19 @@ const profileSchema = new mongoose.Schema({
     type: Number, 
     default: 1 
   },
-  rankings: [{
-    user: { 
+  /*
+  For each round, there's an entry containing the profiles that the user
+  swiped left/right on.
+  */
+  rounds: [{
+    swipesRight: [{
       type: mongoose.Schema.Types.ObjectId, 
-      ref: 'Profile' },
-    timestamp: Date
+      ref: 'Profile'
+    }],
+    swipesLeft: [{
+      type: mongoose.Schema.Types.ObjectId, 
+      ref: 'Profile'
+    }]
   }],
   matches: [{ 
     type: mongoose.Schema.Types.ObjectId, 

--- a/server/routes/orgRoutes.js
+++ b/server/routes/orgRoutes.js
@@ -4,15 +4,27 @@ const verifyToken = require('../middleware/authMiddleware');
 const orgController = require('../controllers/orgController');
 
 router.route('/organizations')
-    .get(orgController.getOrganizations);
+  .get(orgController.getOrganizations);
 
 router.route('/create-org')
-    .post(orgController.createOrganization);
+  .post(orgController.createOrganization);
 
 router.route('/organizations/:orgId')
-    .get(orgController.getOrganizationById);
+  .get(orgController.getOrganizationById);
 
 router.route('/organizations/:orgId/members')
-    .get(orgController.getOrganizationMembers);
+  .get(orgController.getOrganizationMembers);
+
+// User must be logged in for matches
+router.use('/organizations/:orgId/matches', verifyToken);
+
+router.route('/organizations/:orgId/matches/profiles')
+  .get(orgController.getMatchProfiles);
+
+router.route('/organizations/:orgId/matches/swipeLeft/:profileId')
+  .post(orgController.swipeLeft);
+
+router.route('/organizations/:orgId/matches/swipeRight/:profileId')
+  .post(orgController.swipeRight);
 
 module.exports = router;


### PR DESCRIPTION
- Made matches page load profiles from the database.
- Swiping sorts the users into the match arrays.
  - Modified the `Profile` schema to now contain `rounds` instead of `rankings`, where each entry (round) contains arrays for the profiles swiped left and right on.
- Added no matching right now and matching completed message.

To implement these, I added `react-native-deck-swiper` as a dependency. I also created the following matching routes (currently under organization):
- GET `/organizations/:orgId/matches/profiles`
- POST `/organizations/:orgId/matches/swipeLeft/:profileId`
- POST `/organizations/:orgId/matches/swipeRight/:profileId`

---

Some other changes:
- Documented AWS secrets in `.env.example`.
- Modified controller logic to prefer returning all fields of an object rather than select fields.

Resolves #96. 